### PR TITLE
xUAC: added AlwaysNotifyAndAskForCredentials option (Fixes #8)

### DIFF
--- a/DSCResources/xUAC/xUAC.schema.psm1
+++ b/DSCResources/xUAC/xUAC.schema.psm1
@@ -20,7 +20,13 @@ Configuration xUac
             $ConsentPromptBehaviorAdmin = 2
             $EnableLua = 1
             $PromptOnSecureDesktop = 1
-        }    
+        }
+        "AlwaysNotifyAndAskForCredentials" 
+        {
+            $ConsentPromptBehaviorAdmin = 3
+            $EnableLua = 1
+            $PromptOnSecureDesktop = 1
+        }       
         "NotifyChanges" 
         {
             $ConsentPromptBehaviorAdmin = 5

--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ Please refer to [this article](http://technet.microsoft.com/en-us/library/dd8832
 ## Versions
 
 ### Unreleased
+* Added xUAC-Setting AlwaysNotifyAndAskForCredentials 
 
 ### 1.2.0.0
 * Converted appveyor.yml to install Pester from PSGallery instead of from Chocolatey.

--- a/README.md
+++ b/README.md
@@ -23,6 +23,9 @@ Please check out common DSC Resources [contributing guidelines](https://github.c
     When you're notified, your desktop will be dimmed, and you must either approve or deny the request in the UAC dialog box before you can do anything else on your computer. 
     The dimming of your desktop is referred to as the secure desktop because other programs can't run while it's dimmed.
     This is the most secure setting.
+    - **AlwaysNotifyAndAskForCredentials**: You will be notified before programs make changes to your computer or to Windows settings that require the permissions of an administrator.
+    When you're notified, your desktop will be dimmed, and you must enter valid credentials to approve the request in the UAC dialog box. 
+    This setting is the same as "AlwaysNotify" but you are always asked for valid credentials on the secure desktop.
     When you are notified, you should carefully read the contents of each dialog box before allowing changes to be made to your computer.
     - **NotifyChanges**: You will be notified before programs make changes to your computer that require the permissions of an administrator.
     You will not be notified if you try to make changes to Windows settings that require the permissions of an administrator.


### PR DESCRIPTION
Hi @kwirkykat  @Zulgrib

My PR contains:
A new option AlwaysNotifyAndAskForCredentials for xUAC which can be used to configure UAC to always ask for credentials.

Let me know if there are any issues.

Fixes #8

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/xsystemsecurity/10)

<!-- Reviewable:end -->
