### PR TITLE
Updated FileSystemACL Set

### DIFF
--- a/DSCResources/MSFT_xFileSystemAccessRule/MSFT_xFileSystemAccessRule.psm1
+++ b/DSCResources/MSFT_xFileSystemAccessRule/MSFT_xFileSystemAccessRule.psm1
@@ -123,7 +123,7 @@ function Set-TargetResource
         throw "Unable to get ACL for '$Path' as it does not exist"
     }
 
-    $acl = (Get-Item -Path $Path).GetAccessControl('Access')
+    $acl = Get-ACLAccess -Path $Path
     $accessRules = $acl.Access
 
     if ($Ensure -eq "Present")
@@ -229,6 +229,10 @@ function Test-TargetResource
     }
 
     return $true
+}
+ Function Get-ACLAccess($Path)
+{
+    return (Get-Item -Path $Path).GetAccessControl('Access')
 }
 
 Export-ModuleMember -Function *-TargetResource

--- a/DSCResources/MSFT_xFileSystemAccessRule/MSFT_xFileSystemAccessRule.psm1
+++ b/DSCResources/MSFT_xFileSystemAccessRule/MSFT_xFileSystemAccessRule.psm1
@@ -123,7 +123,7 @@ function Set-TargetResource
         throw "Unable to get ACL for '$Path' as it does not exist"
     }
 
-    $acl = Get-Acl -Path $Path
+    $acl = (Get-Item -Path $Path).GetAccessControl('Access')
     $accessRules = $acl.Access
 
     if ($Ensure -eq "Present")

--- a/Tests/Unit/MSFT_xFileSystemAccessRule.tests.ps1
+++ b/Tests/Unit/MSFT_xFileSystemAccessRule.tests.ps1
@@ -37,6 +37,13 @@ try
                     } | Add-Member -MemberType ScriptMethod -Name "SetAccessRule" -Value {} -PassThru `
                       | Add-Member -MemberType ScriptMethod -Name "RemoveAccessRule" -Value {} -PassThru
                 }
+
+                Mock Get-ACLAccess { 
+                    return @{
+                        Access = @()
+                    } | Add-Member -MemberType ScriptMethod -Name "SetAccessRule" -Value {} -PassThru `
+                      | Add-Member -MemberType ScriptMethod -Name "RemoveAccessRule" -Value {} -PassThru
+                }
                 
                 It "should return absent from the get method" {
                     (Get-TargetResource @testParams).Ensure | Should Be "Absent"
@@ -59,6 +66,18 @@ try
                     Rights = @("Read","Synchronize")
                 }
                 Mock Get-Acl { 
+                    return @{
+                        Access = @(
+                            @{
+                                IdentityReference = $testParams.Identity
+                                FileSystemRights = [System.Security.AccessControl.FileSystemRights]::FullControl
+                            }
+                        )
+                    } | Add-Member -MemberType ScriptMethod -Name "SetAccessRule" -Value {} -PassThru `
+                      | Add-Member -MemberType ScriptMethod -Name "RemoveAccessRule" -Value {} -PassThru
+                }
+
+                 Mock Get-ACLAccess { 
                     return @{
                         Access = @(
                             @{

--- a/Tests/Unit/MSFT_xFileSystemAccessRule.tests.ps1
+++ b/Tests/Unit/MSFT_xFileSystemAccessRule.tests.ps1
@@ -37,7 +37,7 @@ try
                     } | Add-Member -MemberType ScriptMethod -Name "SetAccessRule" -Value {} -PassThru `
                       | Add-Member -MemberType ScriptMethod -Name "RemoveAccessRule" -Value {} -PassThru
                 }
-
+                
                 It "should return absent from the get method" {
                     (Get-TargetResource @testParams).Ensure | Should Be "Absent"
                 }
@@ -118,6 +118,18 @@ try
                     Ensure = "Absent"
                 }
                 Mock Get-Acl { 
+                    return @{
+                        Access = @(
+                            @{
+                                IdentityReference = $testParams.Identity
+                                FileSystemRights = [System.Security.AccessControl.FileSystemRights]::FullControl
+                            }
+                        )
+                    } | Add-Member -MemberType ScriptMethod -Name "SetAccessRule" -Value {} -PassThru `
+                      | Add-Member -MemberType ScriptMethod -Name "RemoveAccessRule" -Value {} -PassThru
+                }
+
+                Mock Get-ACLAccess { 
                     return @{
                         Access = @(
                             @{


### PR DESCRIPTION
Modified the the way the ACL is built in the Set command. Please see:
https://github.com/PowerShell/xSystemSecurity/issues/11

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/xsystemsecurity/14)
<!-- Reviewable:end -->
